### PR TITLE
fix theoretical out-of-bounds write

### DIFF
--- a/tftpd.hpp
+++ b/tftpd.hpp
@@ -190,7 +190,7 @@ protected:
         }
 
         size_t const extra = TFTP_HEADER + 1; // include strend '\0'
-        err_msg.resize(std::min(err_msg.size(), PKTSIZE - TFTP_HEADER));
+        err_msg.resize(std::min(err_msg.size(), PKTSIZE - extra));
         size_t const length = err_msg.size() + extra;
 
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access)


### PR DESCRIPTION
There is a theoretical one character out-of-bounds write in send_error() in case the error message would be SEGSIZE characters long (or longer). Shouldn't happen in practice, as all error messages currently are way shorter.